### PR TITLE
Apply lazy_required when inheriting from existing attributes

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,7 +1,7 @@
 Change history for distribution MooseX-LazyRequire
 
 {{$NEXT}}
-  - Let people specify lazy_required when inheriting attributes (Sam Kington)
+  - Let people specify lazy_required when inheriting attributes (Sam Kington).
     This is RT#76054.
 
 0.11      2014-08-16 20:49:14Z

--- a/Changes
+++ b/Changes
@@ -1,6 +1,8 @@
 Change history for distribution MooseX-LazyRequire
 
 {{$NEXT}}
+  - Let people specify lazy_required when inheriting attributes (Sam Kington)
+    This is RT#76054.
 
 0.11      2014-08-16 20:49:14Z
   - lots of cleanup of metadata

--- a/lib/MooseX/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire.pm
@@ -52,7 +52,7 @@ unless a value for the attributes was provided earlier by a constructor
 parameter or through a writer method.
 
 You can override an attribute declaration in a parent class, either enabling
-or disabling lazy-required. Note, though, that becaus lazy_required works by
+or disabling lazy-required. Note, though, that because lazy_required works by
 declaring a default value that's evaluated lazily, if you say "never mind, this
 attribute isn't lazy-required any more", you I<still> need to provide a
 default value or coderef. B<Especially> if C<undef> isn't a valid value for

--- a/lib/MooseX/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire.pm
@@ -34,13 +34,13 @@ use namespace::autoclean;
     Foo->new;            # fails, neither foo nor bare were given
 
     package Foo::Nevermind;
-    
+
     use Moose;
     use MooseX::LazyRequire;
     extends 'Foo';
-    
+
     has foo => ( lazy_required => 0 );
-    
+
     Foo::Nevermind->new;    # succeeds
 
 =head1 DESCRIPTION

--- a/lib/MooseX/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire.pm
@@ -33,6 +33,16 @@ use namespace::autoclean;
     Foo->new(bar => 42); # succeeds, bar will be 42
     Foo->new;            # fails, neither foo nor bare were given
 
+    package Foo::Nevermind;
+    
+    use Moose;
+    use MooseX::LazyRequire;
+    extends 'Foo';
+    
+    has foo => ( lazy_required => 0 );
+    
+    Foo::Nevermind->new;    # succeeds
+
 =head1 DESCRIPTION
 
 This module adds a C<lazy_required> option to Moose attribute declarations.
@@ -40,6 +50,14 @@ This module adds a C<lazy_required> option to Moose attribute declarations.
 The reader methods for all attributes with that option will throw an exception
 unless a value for the attributes was provided earlier by a constructor
 parameter or through a writer method.
+
+You can override an attribute declaration in a parent class, either enabling
+or disabling lazy-required. Note, though, that becaus lazy_required works by
+declaring a default value that's evaluated lazily, if you say "never mind, this
+attribute isn't lazy-required any more", you I<still> need to provide a
+default value or coderef. B<Especially> if C<undef> isn't a valid value for
+your attribute, because that's what MooseX::LazyRequire will try to enforce
+in the absence of any better guidance.
 
 =head1 CAVEATS
 

--- a/lib/MooseX/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire.pm
@@ -39,7 +39,7 @@ use namespace::autoclean;
     use MooseX::LazyRequire;
     extends 'Foo';
 
-    has foo => ( lazy_required => 0 );
+    has '+foo' => ( lazy_required => 0 );
 
     Foo::Nevermind->new;    # succeeds
 

--- a/lib/MooseX/LazyRequire/Meta/Attribute/Trait/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire/Meta/Attribute/Trait/LazyRequire.pm
@@ -54,7 +54,7 @@ around clone_and_inherit_options => sub {
 
     if ($options{lazy_required}) {
         $self->_enable_lazy_required($self->name, \%options);
-    } else {
+    } elsif (exists $options{lazy_required}) {
         # Disable lazy and required, unless we were told "actually, I like
         # that part of lazy-required".
         for my $boolean_option (qw(lazy required)) {

--- a/lib/MooseX/LazyRequire/Meta/Attribute/Trait/LazyRequire.pm
+++ b/lib/MooseX/LazyRequire/Meta/Attribute/Trait/LazyRequire.pm
@@ -31,7 +31,7 @@ after _process_options => sub {
 
 sub _enable_lazy_required {
     my ($class, $name, $options) = @_;
-    
+
     # lazy_required + default or builder doesn't make sense because if there
     # is a default/builder, the reader will always be able to return a value.
     Moose->throw_error(

--- a/t/basic.t
+++ b/t/basic.t
@@ -6,7 +6,7 @@ use Test::Fatal;
 {
     package Vanilla;
     use Moose;
-    
+
     has flavour => ( is => 'ro' );
 }
 

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -29,11 +29,11 @@ use Test::Fatal;
 
     # A further subclass insists that you supply the password immediately.
     package AccountExt::Harsh;
-    
+
     use Moose;
     extends 'AccountExt';
     use MooseX::LazyRequire;
-    
+
     has '+password' => (
         is            => 'ro',
         lazy_required => 0,
@@ -42,11 +42,11 @@ use Test::Fatal;
 
     # Another subclass makes the attribute lazy.
     package AccountExt::Lazy;
-    
+
     use Moose;
     extends 'AccountExt';
     use MooseX::LazyRequire;
-    
+
     $AccountExt::Lazy::default_password = 'password';
     has '+password' => (
         lazy_required => 0,
@@ -56,7 +56,7 @@ use Test::Fatal;
 
     # Another subclass will supply one for you if you don't specify one.
     package AccountExt::Lax::Default;
-    
+
     use Moose;
     extends 'AccountExt';
     use MooseX::LazyRequire;
@@ -68,11 +68,11 @@ use Test::Fatal;
 
     # But if you don't override the default, you're SOL.
     package AccountExt::Lax::Woo;
-    
+
     use Moose;
     extends 'AccountExt';
     use MooseX::LazyRequire;
-    
+
     has '+password' => (lazy_required => 0);
 }
 

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -5,6 +5,7 @@ use Test::More 0.88;
 use Test::Fatal;
 
 {
+    # Our base class has an attribute that's nothing special.
     package Account;
     use Moose;
     use MooseX::LazyRequire;
@@ -14,6 +15,7 @@ use Test::Fatal;
         isa => 'Str',
     );
 
+    # The extended class wants you to specify a password.
     package AccountExt;
 
     use Moose;
@@ -29,7 +31,8 @@ use Test::Fatal;
         lazy_required => 1,
     );
 
-    package AccountExt::Lax;
+    # A further subclass will supply one for you if you don't specify one.
+    package AccountExt::Lax::Default;
     
     use Moose;
     extends 'AccountExt';
@@ -40,8 +43,9 @@ use Test::Fatal;
         default       => sub { 'hunter2' },
     );
 }
-my $r = AccountExt->new;
 
+# In the extension class, asking about a password generates an exception.
+my $r = AccountExt->new;
 my $e = exception { $r->password };
 isnt($e, undef, 'works on inherited attributes: exception') &&
 like(
@@ -50,6 +54,7 @@ like(
     'works on inherited attributes: mentions password by name'
 );
 
+# The lax subclass is happy to provide you with a default password.
 my $lax = AccountExt::Lax->new;
 is($lax->password, 'hunter2', 'We can override LazyRequired *off* as well');
 

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -86,11 +86,11 @@ my $default_description = 'Clearly nothing that you care about';
     # If you don't mention lazy_required *at all* when overriding an
     # attribute, that's fine.
     package Account::Logged;
-    
+
     use Moose;
     extends 'Account';
     use MooseX::LazyRequire;
-    
+
     has 'description_history' => (
         is      => 'rw',
         isa     => 'ArrayRef',

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -119,6 +119,14 @@ my $attribute_ext = $account_ext->meta->find_attribute_by_name('password');
 ok($attribute_ext->lazy_required,
     'The inherited attribute is now lazy-required');
 
+# These subclasses turn lazy_required *off* again, sometimes adding in elements
+# that lazy_required provides.
+# The lax subclass is happy to provide you with a default password.
+my $account_ext_lax_default = AccountExt::Lax::Default->new;
+is($account_ext_lax_default->password,
+    'hunter2',
+    'We can override LazyRequired *off* as well');
+
 # The harsh subclass generates an exception as soon as you don't provide a
 # password.
 my $exception_harsh_constructor = exception { AccountExt::Harsh->new };
@@ -133,12 +141,6 @@ my $lazy = AccountExt::Lazy->new;
         'The lazy object resolves its default value as late as possible'
     );
 }
-
-# The lax subclass is happy to provide you with a default password.
-my $account_ext_lax_default = AccountExt::Lax::Default->new;
-is($account_ext_lax_default->password,
-    'hunter2',
-    'We can override LazyRequired *off* as well');
 
 # The woo subclass really wants to be the base subclass, but can't, because
 # a default option got in the way in the inheritance hierarchy.

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -15,7 +15,7 @@ use Test::Fatal;
         isa => 'Str',
     );
 
-    # The extended class wants you to specify a password.
+    # The extended class wants you to specify a password, eventually.
     package AccountExt;
 
     use Moose;
@@ -25,9 +25,6 @@ use Test::Fatal;
 
     has '+password' => (
         is            => 'ro',
-        # Probably there also should be:
-        # traits => ['LazyRequire'],
-        # but I'm not sure
         lazy_required => 1,
     );
 
@@ -44,7 +41,8 @@ use Test::Fatal;
     );
 }
 
-# In the extension class, asking about a password generates an exception.
+# In the extension class, asking about a password generates an exception,
+# when you ask about it.
 my $account_ext = AccountExt->new;
 my $exception_ext = exception { $account_ext->password };
 isnt($exception_ext, undef, 'works on inherited attributes: exception') &&
@@ -53,6 +51,9 @@ like(
     qr/Attribute 'password' must be provided before calling reader/,
     'works on inherited attributes: mentions password by name'
 );
+my $attribute_ext = $account_ext->meta->find_attribute_by_name('password');
+ok($attribute_ext->lazy_required,
+    'The inherited attribute is now lazy-required');
 
 # The lax subclass is happy to provide you with a default password.
 my $account_ext_lax_default = AccountExt::Lax::Default->new;

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -45,17 +45,19 @@ use Test::Fatal;
 }
 
 # In the extension class, asking about a password generates an exception.
-my $r = AccountExt->new;
-my $e = exception { $r->password };
-isnt($e, undef, 'works on inherited attributes: exception') &&
+my $account_ext = AccountExt->new;
+my $exception_ext = exception { $account_ext->password };
+isnt($exception_ext, undef, 'works on inherited attributes: exception') &&
 like(
-    exception { $r->password },
+    $exception_ext,
     qr/Attribute 'password' must be provided before calling reader/,
     'works on inherited attributes: mentions password by name'
 );
 
 # The lax subclass is happy to provide you with a default password.
-my $lax = AccountExt::Lax->new;
-is($lax->password, 'hunter2', 'We can override LazyRequired *off* as well');
+my $account_ext_lax_default = AccountExt::Lax::Default->new;
+is($account_ext_lax_default->password,
+    'hunter2',
+    'We can override LazyRequired *off* as well');
 
 done_testing;

--- a/t/rt76054_inheritance.t
+++ b/t/rt76054_inheritance.t
@@ -4,8 +4,6 @@ use warnings;
 use Test::More 0.88;
 use Test::Fatal;
 
-local $TODO = 'RT#75054';
-
 {
     package Account;
     use Moose;
@@ -31,15 +29,28 @@ local $TODO = 'RT#75054';
         lazy_required => 1,
     );
 
+    package AccountExt::Lax;
+    
+    use Moose;
+    extends 'AccountExt';
+    use MooseX::LazyRequire;
+
+    has '+password' => (
+        lazy_required => 0,
+        default       => sub { 'hunter2' },
+    );
 }
 my $r = AccountExt->new;
 
 my $e = exception { $r->password };
-isnt($e, undef, 'works on inherited attributes') &&
+isnt($e, undef, 'works on inherited attributes: exception') &&
 like(
     exception { $r->password },
     qr/Attribute 'password' must be provided before calling reader/,
-    'works on inherited attributes'
+    'works on inherited attributes: mentions password by name'
 );
+
+my $lax = AccountExt::Lax->new;
+is($lax->password, 'hunter2', 'We can override LazyRequired *off* as well');
 
 done_testing;


### PR DESCRIPTION
This is [a bug that was reported 8 years ago](https://rt.cpan.org/Public/Bug/Display.html?id=76054), and has been bugging me on-and-off for a while.

Basically, because [_process_options isn't called if you're inheriting from another class](https://github.com/moose/Moose/blob/303a3f0bbe5ff18b68415274c78feca081c20610/lib/Moose/Meta/Attribute.pm#L57), lazy_required wasn't getting applied in a sub-class. There was an initial test class supplied in the bug report that I've used as a base; I've updated some of the wording to (in my mind) make it clearer what we're trying to test.